### PR TITLE
fix: change to commitish value

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -43,7 +43,7 @@ jobs:
           release_name: ${{ steps.current_version.outputs.version }}
           draft: false
           prerelease: false
-          target_commitish: ${{ github.ref_name }}
+          commitish: ${{ github.event.repository.default_branch }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Release


### PR DESCRIPTION
## Type
### 🤖 Generated by PR Agent at a2303585902dcd4f1151a23433cace066176100e

['Bug fix']

## Description
### 🤖 Generated by PR Agent at a2303585902dcd4f1151a23433cace066176100e

- `target_commitish`を`commitish`に変更し、デフォルトブランチを使用するように設定しました。
- GitHub Actionsのリリース作成時の挙動を改善しました。

## Walkthrough
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>GitHub Actionsのデプロイメント設定の修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deployment.yaml

<li><code>target_commitish</code>の値を<code>commitish</code>に変更<br> <li> <code>commitish</code>の値を<code>github.event.repository.default_branch</code>に設定<br>


</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/2/files#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

## Summary
<!-- Summary of main changes here -->

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

