### PR TITLE
ci: explicitly state that token is to be used

### DIFF
--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -53,3 +53,5 @@ jobs:
           asset_path: output/artifacts.zip
           asset_name: citrus_bluesky_plugin_${{ steps.current_version.outputs.version }}.zip
           asset_content_type: application/zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Type
### 🤖 Generated by PR Agent at a5ab26ca95386711170d726211302e71c71b1ad2

['Other']

## Description
### 🤖 Generated by PR Agent at a5ab26ca95386711170d726211302e71c71b1ad2

- `GITHUB_TOKEN` 環境変数を設定し、GitHub Actions のワークフローを強化しました。
- これにより、トークンの使用が明示的に指定され、セキュリティが向上します。

## Walkthrough
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>GitHub Actions ワークフローのトークン設定</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deployment.yaml

- `GITHUB_TOKEN` 環境変数を追加
- GitHub Actions のワークフローを更新



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/3/files#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

## Summary
<!-- Summary of main changes here -->

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

