### PR TITLE
feat: release plugin on GitHub

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     volumes:
       - node_modules:/home/bun/app/node_modules
       - ../:/home/bun/app:cached
-      - $HOME/Documents/Obsidian Vault/.obsidian/plugins/obsidian_bluesky_plugin:/home/bun/app/dist:cached
+      - $HOME/Documents/Obsidian Vault/.obsidian/plugins/citrus_bluesky_plugin:/home/bun/app/dist:cached
     tty: true
     stdin_open: true
 

--- a/.github/push.default.json
+++ b/.github/push.default.json
@@ -1,0 +1,8 @@
+{
+  "ref": "refs/heads/master",
+  "head": {
+    "user": {
+      "login": "act"
+    }
+  }
+}

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -1,19 +1,15 @@
 name: Deploy to Release
-
 on:
-  pull_request:
-    types: [closed]
+  push:
 
 jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-20.04
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == github.event.repository.default_branch
+    if: github.ref == github.event.repository.default_branch
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
       - name: Install
         if: ${{ github.event.head.user.login == 'act' }}
         run: |
@@ -27,14 +23,15 @@ jobs:
         run: |
           bun install --frozen-lockfile --ignore-scripts
           bun run build
-      - name: Create ZIP
-        run: |
-          mkdir -p output
-          zip -r output/artifacts.zip dist/
       - name: Get Version
         id: current_version
         run: |
           echo "version=v$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+      - name: Create ZIP
+        run: |
+          mkdir -p output
+          mv dist citrus_bluesky_plugin_${{ steps.current_version.outputs.version }}
+          zip -r output/artifacts.zip citrus_bluesky_plugin_${{ steps.current_version.outputs.version }}/
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/deployment.yaml
+++ b/.github/workflows/deployment.yaml
@@ -6,7 +6,7 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-20.04
-    if: github.ref == github.event.repository.default_branch
+    if: github.ref == 'refs/heads/' + ${{ github.event.repository.default_branch }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -26,18 +26,20 @@ jobs:
       - name: Get Version
         id: current_version
         run: |
-          echo "version=v$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
+          echo "version=$(cat package.json | jq -r '.version')" >> $GITHUB_OUTPUT
       - name: Create ZIP
         run: |
           mkdir -p output
+          sed -i "s/\"version\": \".*\"/\"version\": \"${{ steps.current_version.outputs.version }}\"/" dist/manifest.json
+          cat dist/manifest.json
           mv dist citrus_bluesky_plugin_${{ steps.current_version.outputs.version }}
           zip -r output/artifacts.zip citrus_bluesky_plugin_${{ steps.current_version.outputs.version }}/
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ steps.current_version.outputs.version }}
-          release_name: ${{ steps.current_version.outputs.version }}
+          tag_name: v${{ steps.current_version.outputs.version }}
+          release_name: v${{ steps.current_version.outputs.version }}
           draft: false
           prerelease: false
           commitish: ${{ github.event.repository.default_branch }}

--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,13 @@ PHONY: check
 check:
 	act -j check -P ubuntu-24.04=catthehacker/ubuntu:act-22.04
 
+# PHONY: deploy
+# deploy:
+# 	act -j deploy -P ubuntu-24.04=catthehacker/ubuntu:act-22.04 -s GITHUB_TOKEN=${GITHUB_TOKEN} --eventpath .github/pull_request.closed.develop.json
+
 PHONY: deploy
 deploy:
-	act -j deploy -P ubuntu-24.04=catthehacker/ubuntu:act-22.04 -s GITHUB_TOKEN=${GITHUB_TOKEN} --eventpath .github/pull_request.closed.develop.json
+	act -j deploy -P ubuntu-24.04=catthehacker/ubuntu:act-22.04 -s GITHUB_TOKEN=${GITHUB_TOKEN} --eventpath .github/push.default.json
 
 PHONY: validate
 validate:

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
-	"id": "citrus-bluesky-plugin",
-	"name": "Citrus",
-	"version": "0.1.0",
-	"minAppVersion": "0.15.0",
-	"description": "Display timeline and post notes using Bluesky API.",
-	"author": "tkgstrator",
-	"authorUrl": "https://obsidian.md",
-	"fundingUrl": "https://obsidian.md/pricing",
-	"isDesktopOnly": true
+  "id": "citrus",
+  "name": "Citrus",
+  "version": "0.1.0",
+  "minAppVersion": "0.15.0",
+  "description": "Display timeline and post notes using Bluesky API.",
+  "author": "tkgstrator",
+  "authorUrl": "https://obsidian.md",
+  "fundingUrl": "https://obsidian.md/pricing",
+  "isDesktopOnly": true
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,11 +31,11 @@ export default class CitrusPlugin extends Plugin {
 
   async loadSettings() {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
-    const result = await this.client.login(this.settings)
   }
 
   async saveSettings() {
     await this.saveData(this.settings)
+    const result = await this.client.login(this.settings)
   }
 
   async toggleView() {


### PR DESCRIPTION
## Type
### 🤖 Generated by PR Agent at 8f49246fd476979091a6fbea5847807da6d45909

['Enhancement', 'Other']

## Description
### 🤖 Generated by PR Agent at 8f49246fd476979091a6fbea5847807da6d45909

- `loadSettings` メソッドから `saveSettings` メソッドへの `client.login` の移動を行いました。
- プラグインのパスを `citrus_bluesky_plugin` に変更しました。
- GitHub Actions のデプロイメントワークフローをプッシュイベントに基づくように修正しました。
- プラグインのIDを `citrus` に変更しました。

## Walkthrough
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>main.ts</strong><dd><code>`loadSettings` から `saveSettings` への `client.login` 移動</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main.ts

- `loadSettings` メソッドでの `client.login` 呼び出しを `saveSettings` メソッドに追加



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>manifest.json</strong><dd><code>プラグインIDの変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

manifest.json

- プラグインのIDを `citrus` に変更



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-ffa5b716b5a57837f7929dfcca4b4dfdeb97210a7fd5a12d2f1978846d6f1743">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose.yaml</strong><dd><code>プラグインパスの変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.devcontainer/docker-compose.yaml

- プラグインのパスを `citrus_bluesky_plugin` に変更



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-e96a798889398aad623ee0fa8ef4d316b5a72a5383f4534acbe805619458f263">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>push.default.json</strong><dd><code>プッシュイベントのデフォルト設定追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/push.default.json

- GitHub Actions のデフォルトプッシュイベント設定を追加



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-25d73b85429942db1465c399cacd4574e8b7d91c3dbfd62e8bf91ad82c6b33ad">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>deployment.yaml</strong><dd><code>デプロイメントワークフローの修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deployment.yaml

- プルリクエストのマージ条件をプッシュイベントに変更
- ZIPファイル作成の手順を修正



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-259f2188de53828dcb003900d2a84cfd00a909870115a6e14ddc019e96255087">+12/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>デプロイメントイベントパスの変更</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

- デプロイメントのイベントパスをプッシュイベントに変更



</details>


  </td>
  <td><a href="https://github.com/tkgstrator/obsidian_bluesky_plugin/pull/7/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

## Summary
<!-- Summary of main changes here -->

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

